### PR TITLE
Dont use SSL when calling ip-api because SSL is not free anymore

### DIFF
--- a/translators/apis.py
+++ b/translators/apis.py
@@ -133,7 +133,7 @@ class TranslatorSeverRegion:
         try:
             ip_address = requests.get('https://httpbin.org/ip').json()['origin']
             try:
-                data = requests.get(f'https://ip-api.com/json/{ip_address}', timeout=10).json() # limit 45/min.
+                data = requests.get(f'http://ip-api.com/json/{ip_address}', timeout=10).json() # limit 45/min.
                 country = data.get("country")
                 assert country
                 sys.stderr.write(f'Using {country} server backend.\n')


### PR DESCRIPTION
When importing translators I get the following error:

>>> import translators
/usr/local/lib/python3.7/dist-packages/translators/apis.py:152: UserWarning: Unable to find server backend.

  warnings.warn('Unable to find server backend.\n')
Please input your server region need to visit:
eg: [England, China, ...]


- This is because call to https://ip-api.com/json/{ip_address} fails with the following error:

{"status":"fail","message":"SSL unavailable for this endpoint, order a key at https://members.ip-api.com/"}

Using HTTP without SSL fixes the error