### PR TITLE
:sparkle: Add CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,30 @@ translate_text(query_text: str, translator: str = 'bing', from_language: str = '
 """
 ```
 
+## CLI
+
+You can leverage a simple CLI that ships with **translators**.
+
+```
+> translate --help                                                                                                                                                                                                                               ─╯
+usage: translate [-h] [-p PROVIDER] [-f FROM_LANGUAGE] [-t TO_LANGUAGE] [--version] input
+
+Bring free, multiple, enjoyable translations to individuals and students.
+
+positional arguments:
+  input                 Raw text or path to a file to be translated
+
+options:
+  -h, --help            show this help message and exit
+  -p PROVIDER, --provider PROVIDER
+                        Choose one of the supported providers. e.g. bing, google, yandex, bing etc...
+  -f FROM_LANGUAGE, --from FROM_LANGUAGE
+                        Enforce the language of origin. By default it is auto detected.
+  -t TO_LANGUAGE, --to TO_LANGUAGE
+                        Set the destination language. Always default to english.
+  --version             Show version information and exit.
+```
+
 ## Supported Languages
 
 | Language             | Language of Translator | [Google](https://translate.google.com) | [Yandex](https://translate.yandex.com) | [Bing](https://www.bing.com/Translator) | [Baidu](https://fanyi.baidu.com) | [Alibaba](https://translate.alibaba.com) | [Tencent](https://fanyi.qq.com) | [Youdao](https://fanyi.youdao.com) | [Sogou](https://fanyi.sogou.com) | [Deepl](https://www.deepl.com/translator) | [Caiyun](https://fanyi.caiyunapp.com) | [Argos](https://translate.argosopentech.com) | others... |

--- a/setup.py
+++ b/setup.py
@@ -71,4 +71,10 @@ setuptools.setup(
     python_requires='>=3.8',
     extras_require={'pypi': ['build>=1.2.2', 'twine>=5.1.1']},
     zip_safe=False,
+    entry_points={
+        'console_scripts':
+            [
+                'translate = translators.__main__:main'
+            ]
+    },
 )

--- a/translators/__main__.py
+++ b/translators/__main__.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import os.path
+import re
+import sys
+from platform import python_version
+
+from . import __version__, translate_text, translate_html
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Bring free, multiple, enjoyable translations to individuals and students."
+    )
+
+    parser.add_argument(
+        "input",
+        help="Raw text or path to a file to be translated"
+    )
+
+    parser.add_argument(
+        "-p",
+        "--provider",
+        action="store",
+        default="bing",
+        type=str,
+        dest="provider",
+        help="Choose one of the supported providers. e.g. bing, google, yandex, bing etc...",
+    )
+
+    parser.add_argument(
+        "-f",
+        "--from",
+        action="store",
+        default="auto",
+        type=str,
+        dest="from_language",
+        help="Enforce the language of origin. By default it is auto detected.",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--to",
+        action="store",
+        default="en",
+        type=str,
+        dest="to_language",
+        help="Set the destination language. Always default to english.",
+    )
+
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="Translator {} - Python {}".format(
+            __version__,
+            python_version(),
+        ),
+        help="Show version information and exit.",
+    )
+
+    args = parser.parse_args(sys.argv[1:])
+
+    # case file
+    if os.path.exists(args.input):
+        try:
+            with open(args.input, "r", encoding="utf-8") as fp:
+                content_to_translate = fp.read()
+        except UnicodeDecodeError as e:
+            print(f"error: file '{args.input}' is not Unicode. reason: {e}")
+            return 1
+        except (OSError, IOError) as e:
+            print(f"error: file '{args.input}' cannot be opened. reason: {e}")
+            return 2
+    else:
+        content_to_translate = args.input
+
+    is_html = bool(re.findall(r"<(.*)>(.*)</(.*)>", content_to_translate))
+    target_function = translate_html if is_html else translate_text
+
+    try:
+        print(
+            target_function(content_to_translate, translator=args.provider, from_language=args.from_language, to_language=args.to_language)
+        )
+    except Exception as e:
+        print(f"error: unable to translate content. reason: {e}")
+        return 3
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/translators/server.py
+++ b/translators/server.py
@@ -342,7 +342,7 @@ class Region(Tse):
 
         except requests.exceptions.ConnectionError:
             raise TranslatorError('Unable to connect the Internet.\n\n')
-        except:
+        except Exception:
             warnings.warn('Unable to find server backend.\n\n')
             region = input('Please input your server region need to visit:\neg: [Qatar, China, ...]\n\n')
             sys.stderr.write(f'Using region {region} server backend.\n\n')


### PR DESCRIPTION
I (almost) daily use this tool to quickly translate message from various foreign partner, and I built a CLI
that allows to leverage this tool directly from my terminal.

This PR add a CLI, named `translate`.

![image](https://github.com/user-attachments/assets/ff8daeea-352d-4bfe-b5cf-a30a1a03fac5)

Here is the usage:

```
> translate --help                                                                                                                                                                                                                               ─╯
usage: translate [-h] [-p PROVIDER] [-f FROM_LANGUAGE] [-t TO_LANGUAGE] [--version] input

Bring free, multiple, enjoyable translations to individuals and students.

positional arguments:
  input                 Raw text or path to a file to be translated

options:
  -h, --help            show this help message and exit
  -p PROVIDER, --provider PROVIDER
                        Choose one of the supported providers. e.g. bing, google, yandex, bing etc...
  -f FROM_LANGUAGE, --from FROM_LANGUAGE
                        Enforce the language of origin. By default it is auto detected.
  -t TO_LANGUAGE, --to TO_LANGUAGE
                        Set the destination language. Always default to english.
  --version             Show version information and exit.
```